### PR TITLE
Feat/youtrack efs

### DIFF
--- a/helm/aws-efs-csi-driver-helm/.helmignore
+++ b/helm/aws-efs-csi-driver-helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/aws-efs-csi-driver-helm/CHANGELOG.md
+++ b/helm/aws-efs-csi-driver-helm/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Helm chart
+
+# v2.0.0
+
+## Breaking changes
+
+Multiple changes in values file at `sidecars`, `controller` and `node`
+
+---
+```yaml
+sidecars:
+  xxxxxxxxx:
+    repository:
+    tag:
+```
+
+Moving to
+
+```yaml
+sidecars:
+  xxxxxxxxx:
+    image:
+      repository:
+      tag:
+```
+
+---
+```yaml
+podAnnotations:
+resources:
+nodeSelector:
+tolerations:
+affinity:
+```
+
+Moving to
+
+```yaml
+controller:
+  podAnnotations:
+  resources:
+  nodeSelector:
+  tolerations:
+  affinity:
+```
+
+---
+```yaml
+hostAliases:
+dnsPolicy:
+dnsConfig:
+```
+
+Moving to
+
+```yaml
+node:
+  hostAliases:
+  dnsPolicy:
+  dnsConfig:
+```
+
+---
+```yaml
+serviceAccount:
+  controller:
+```
+
+Moving to
+
+```yaml
+controller:
+  serviceAccount:
+```
+
+## New features
+
+* Chart API `v2` (requires Helm 3)
+* Set `resources` and `imagePullPolicy` fields independently for containers
+* Set `logLevel`, `affinity`, `nodeSelector`, `podAnnotations` and `tolerations` fields independently
+for Controller deployment and Node daemonset
+* Set `reclaimPolicy` and `volumeBindingMode` fields in storage class
+
+## Fixes
+
+* Fixing Controller deployment using `podAnnotations` and `tolerations` values from Node daemonset
+* Let the user define the whole `tolerations` array, default to `- operator: Exists`
+* Default `logLevel` lowered from `5` to `2`
+* Default `imagePullPolicy` everywhere set to `IfNotPresent`

--- a/helm/aws-efs-csi-driver-helm/Chart.yaml
+++ b/helm/aws-efs-csi-driver-helm/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: aws-efs-csi-driver
+version: 2.0.0
+appVersion: 1.2.1
+kubeVersion: ">=1.17.0-0"
+description: "A Helm chart for AWS EFS CSI Driver"
+home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
+sources:
+  - https://github.com/kubernetes-sigs/aws-efs-csi-driver
+keywords:
+  - aws
+  - efs
+  - csi
+maintainers:
+  - name: leakingtapan
+    url: https://github.com/leakingtapan
+  - name: krmichel
+    url: https://github.com/krmichel

--- a/helm/aws-efs-csi-driver-helm/templates/NOTES.txt
+++ b/helm/aws-efs-csi-driver-helm/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that aws-efs-csi-driver has started, run:
+
+    kubectl get pod -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "aws-efs-csi-driver.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/aws-efs-csi-driver-helm/templates/_helpers.tpl
+++ b/helm/aws-efs-csi-driver-helm/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-efs-csi-driver.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-efs-csi-driver.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-efs-csi-driver.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-efs-csi-driver.labels" -}}
+app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+helm.sh/chart: {{ include "aws-efs-csi-driver.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-efs-csi-driver.serviceAccountName" -}}
+{{- if .Values.controller.create -}}
+    {{ default (include "aws-efs-csi-driver.fullname" .) .Values.controller.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.controller.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a string out of the map for controller tags flag
+*/}}
+{{- define "aws-efs-csi-driver.tags" -}}
+{{- $tags := list -}}
+{{ range $key, $val := . }}
+{{- $tags = print $key ":" $val | append $tags -}}
+{{- end -}}
+{{- join " " $tags -}}
+{{- end -}}

--- a/helm/aws-efs-csi-driver-helm/templates/controller-deployment.yaml
+++ b/helm/aws-efs-csi-driver-helm/templates/controller-deployment.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.controller.create }}
+# Controller Service
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: efs-csi-controller
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: efs-csi-controller
+      app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: efs-csi-controller
+        app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.controller.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      hostNetwork: true
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      nodeSelector:
+        kubernetes.io/os: linux
+        {{- with .Values.controller.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      serviceAccountName: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
+      priorityClassName: system-cluster-critical
+      {{- with .Values.controller.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: efs-plugin
+          securityContext:
+            privileged: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            {{- if .Values.controller.tags }}
+            - --tags={{ include "aws-efs-csi-driver.tags" .Values.controller.tags }}
+            {{- end }}
+            - --v={{ .Values.controller.logLevel }}
+            - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: healthz
+              containerPort: 9909
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
+          {{- with .Values.controller.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+        - name: csi-provisioner
+          image: {{ printf "%s:%s" .Values.sidecars.csiProvisioner.image.repository .Values.sidecars.csiProvisioner.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.csiProvisioner.image.pullPolicy }}
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v={{ .Values.controller.logLevel }}
+            - --feature-gates=Topology=true
+            - --leader-election
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- with .Values.sidecars.csiProvisioner.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+        - name: liveness-probe
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.livenessProbe.image.pullPolicy }}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9909
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          {{- with .Values.sidecars.livenessProbe.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+      {{- with .Values.controller.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/aws-efs-csi-driver-helm/templates/controller-serviceaccount.yaml
+++ b/helm/aws-efs-csi-driver-helm/templates/controller-serviceaccount.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.controller.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-provisioner-role
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-provisioner-binding
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aws-efs-csi-driver.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/aws-efs-csi-driver-helm/templates/csidriver.yaml
+++ b/helm/aws-efs-csi-driver-helm/templates/csidriver.yaml
@@ -1,0 +1,10 @@
+apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) }}
+kind: CSIDriver
+metadata:
+  name: efs.csi.aws.com
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/resource-policy": keep
+spec:
+  attachRequired: false

--- a/helm/aws-efs-csi-driver-helm/templates/node-daemonset.yaml
+++ b/helm/aws-efs-csi-driver-helm/templates/node-daemonset.yaml
@@ -1,0 +1,162 @@
+# Node Service
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: efs-csi-node
+  labels:
+    app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+spec:
+  selector:
+    matchLabels:
+      app: efs-csi-node
+      app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: efs-csi-node
+        app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.node.podAnnotations }}
+      annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+    {{- with .Values.node.hostAliases }}
+      hostAliases:
+      {{- range $k, $v := . }}
+        - ip: {{ $v.ip }}
+          hostnames:
+            - {{ $k }}.efs.{{ $v.region }}.amazonaws.com
+      {{- end }}
+    {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        {{- with .Values.node.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+      hostNetwork: true
+      dnsPolicy: {{ .Values.node.dnsPolicy }}
+      {{- with .Values.node.dnsConfig }}
+      dnsConfig: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      priorityClassName: system-node-critical
+      {{- with .Values.node.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: efs-plugin
+          securityContext:
+            privileged: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v={{ .Values.node.logLevel }}
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: efs-state-dir
+              mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /var/amazon/efs
+            - name: efs-utils-config-legacy
+              mountPath: /etc/amazon/efs-legacy
+          ports:
+            - name: healthz
+              containerPort: 9809
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+          {{- with .Values.node.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+        - name: csi-driver-registrar
+          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrar.image.repository .Values.sidecars.nodeDriverRegistrar.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.nodeDriverRegistrar.image.pullPolicy }}
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v={{ .Values.node.logLevel }}
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          {{- with .Values.sidecars.nodeDriverRegistrar.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+        - name: liveness-probe
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
+          imagePullPolicy: {{ .Values.sidecars.livenessProbe.image.pullPolicy }}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9809
+            - --v={{ .Values.node.logLevel }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+          {{- with .Values.sidecars.livenessProbe.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/efs.csi.aws.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: efs-state-dir
+          hostPath:
+            path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /var/amazon/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config-legacy
+          hostPath:
+            path: /etc/amazon/efs
+            type: DirectoryOrCreate

--- a/helm/aws-efs-csi-driver-helm/templates/storageclass.yaml
+++ b/helm/aws-efs-csi-driver-helm/templates/storageclass.yaml
@@ -1,0 +1,26 @@
+{{- range .Values.storageClasses }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .name }}
+  {{- with .annotations }}
+  annotations:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
+provisioner: efs.csi.aws.com
+{{- with .mountOptions }}
+mountOptions:
+{{ toYaml . }}
+{{- end }}
+{{- with .parameters }}
+parameters:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- with .reclaimPolicy }}
+reclaimPolicy: {{ . }}
+{{- end }}
+{{- with .volumeBindingMode }}
+volumeBindingMode: {{ . }}
+{{- end }}
+---
+{{- end }}

--- a/helm/aws-efs-csi-driver-helm/values.yaml
+++ b/helm/aws-efs-csi-driver-helm/values.yaml
@@ -1,0 +1,125 @@
+# Default values for aws-efs-csi-driver.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 2
+
+image:
+  repository: 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/aws-efs-csi-driver
+  tag: "v1.2.1"
+  pullPolicy: IfNotPresent
+
+sidecars:
+  livenessProbe:
+    image:
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+      tag: v2.2.0-eks-1-18-2
+      pullPolicy: IfNotPresent
+    resources: {}
+  nodeDriverRegistrar:
+    image:
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+      tag: v2.1.0-eks-1-18-2
+      pullPolicy: IfNotPresent
+    resources: {}
+  csiProvisioner:
+    image:
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+      tag: v2.1.1-eks-1-18-2
+      pullPolicy: IfNotPresent
+    resources: {}
+
+imagePullSecrets: []
+
+## Controller deployment variables
+
+controller:
+  # Specifies whether a deployment should be created
+  create: true
+  # Number for the log level verbosity
+  logLevel: 2
+  # Add additional tags to access points
+  tags: {}
+    # environment: prod
+    # region: us-east-1
+  # Enable if you want the controller to also delete the
+  # path on efs when deleteing an access point
+  deleteAccessPointRootDir: false
+  podAnnotations: {}
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Specifies whether a service account should be created
+  serviceAccount:
+    create: true
+    ## Enable if EKS IAM for SA is used
+    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
+    name: efs-csi-controller-sa
+    annotations: {
+      eks.amazonaws.com/role-arn: arn:aws:iam::491327797652:role/AmazonEKS_EFS_CSI_DriverRole
+    }
+
+## Node daemonset variables
+
+node:
+  # Number for the log level verbosity
+  logLevel: 2
+  hostAliases: {}
+    # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
+    # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
+    # implementing the suggested solution found here:
+    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
+    # EFS Vol ID, IP, Region
+    # "fs-01234567":
+    #   ip: 10.10.2.2
+    #   region: us-east-2
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
+    # Example config which uses the AWS nameservers
+    # dnsPolicy: "None"
+    # dnsConfig:
+    #   nameservers:
+    #     - 169.254.169.253
+  podAnnotations: {}
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  nodeSelector: {}
+  tolerations:
+    - operator: Exists
+
+storageClasses: []
+# Add StorageClass resources like:
+# - name: efs-sc
+#   annotations:
+#     # Use that annotation if you want this to your default storageclass
+#     storageclass.kubernetes.io/is-default-class: "true"
+#   mountOptions:
+#   - tls
+#   parameters:
+#     provisioningMode: efs-ap
+#     fileSystemId: fs-1122aabb
+#     directoryPerms: "700"
+#     gidRangeStart: "1000"
+#     gidRangeEnd: "2000"
+#     basePath: "/dynamic_provisioning"
+#   reclaimPolicy: Delete
+#   volumeBindingMode: Immediate

--- a/helm/youtrack-2/.helmignore
+++ b/helm/youtrack-2/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/youtrack-2/Chart.yaml
+++ b/helm/youtrack-2/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "2021.5"
+description: Intall jetbrains youtrack on kubernetes with helm
+name: button-youtrack
+version: 0.1.0

--- a/helm/youtrack-2/templates/NOTES.txt
+++ b/helm/youtrack-2/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "..fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "..fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "..fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "..name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm/youtrack-2/templates/_helpers.tpl
+++ b/helm/youtrack-2/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "..name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "..fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "..chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/youtrack-2/templates/deployment.yaml
+++ b/helm/youtrack-2/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "..fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "..name" . }}
+    helm.sh/chart: {{ include "..chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "..name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "..name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      initContainers:
+        - name: "init-{{ .Chart.Name }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          command:
+            - /bin/bash
+            - /run.sh
+          args:
+            - configure
+            - -J-Ddisable.configuration.wizard.on.clean.install=true
+            - --listen-port=8080
+          volumeMounts:
+            - name: "{{ include "..fullname" . }}-conf"
+              mountPath: /opt/youtrack/conf
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          command: ["/bin/bash", "/run.sh"]
+          volumeMounts:
+            - name: "{{ include "..fullname" . }}-data"
+              mountPath: /opt/youtrack/data
+            - name: "{{ include "..fullname" . }}-conf"
+              mountPath: /opt/youtrack/conf
+            - name: "{{ include "..fullname" . }}-logs"
+              mountPath: /opt/youtrack/logs
+            - name: "{{ include "..fullname" . }}-backups"
+              mountPath: /opt/youtrack/backups
+      volumes:
+        - name: "{{ include "..fullname" . }}-data"
+          persistentVolumeClaim:
+            claimName: "efs-claim-{{ include "..fullname" . }}-data"
+        - name: "{{ include "..fullname" . }}-conf"
+          persistentVolumeClaim:
+            claimName: "efs-claim-{{ include "..fullname" . }}-conf"
+        - name: "{{ include "..fullname" . }}-logs"
+          persistentVolumeClaim:
+            claimName: "efs-claim-{{ include "..fullname" . }}-logs"
+        - name: "{{ include "..fullname" . }}-backups"
+          persistentVolumeClaim:
+            claimName: "efs-claim-{{ include "..fullname" . }}-backups"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm/youtrack-2/templates/ingress.yaml
+++ b/helm/youtrack-2/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "..fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "..name" . }}
+    helm.sh/chart: {{ include "..chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/youtrack-2/templates/service.yaml
+++ b/helm/youtrack-2/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "..fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "..name" . }}
+    helm.sh/chart: {{ include "..chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "..name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/youtrack-2/templates/volume-backups.yaml
+++ b/helm/youtrack-2/templates/volume-backups.yaml
@@ -1,0 +1,93 @@
+# {{- $useExisitingVolume := and .Values.existingVolumes.enabled (ne .Values.existingVolumes.backups "") }}
+# {{- if $useExisitingVolume -}}
+# kind: StorageClass
+# apiVersion: storage.k8s.io/v1
+# metadata:
+#   name: "sc-{{ include "..fullname" . }}-backups"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# provisioner: efs.csi.aws.com
+# parameters:
+#   type: gp2
+# reclaimPolicy: Retain
+# mountOptions:
+#   - debug
+# volumeBindingMode: Immediate
+# ---
+# apiVersion: v1
+# kind: PersistentVolume
+# metadata:
+#   name: "pv-{{ include "..fullname" . }}-backups"
+#   labels:
+#     type: amazonEFS
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   capacity:
+#     storage: 10Gi
+#   volumeMode: Filesystem
+#   accessModes:
+#     - ReadWriteOnce
+#   storageClassName: "sc-{{ include "..fullname" . }}-backups"
+#   csi:
+#     driver: efs.csi.aws.com
+#     volumeHandle: fs-8e4b7563
+# ---
+# {{- end -}}
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: "pvc-{{ include "..fullname" . }}-backups"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   {{- if $useExisitingVolume }}
+#   storageClassName: "sc-{{ include "..fullname" . }}-backups"
+#   {{- end }}
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 10Gi
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: "efs-sc-{{ include "..fullname" . }}-backups"
+  annotations:
+    "helm.sh/hook": "pre-install"
+provisioner: efs.csi.aws.com
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "efs-claim-{{ include "..fullname" . }}-backups"
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  # {{- if $useExisitingVolume }}
+  # storageClassName: "sc-{{ include "..fullname" . }}-backups"
+  # {{- end }}
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "efs-sc-{{ include "..fullname" . }}-backups"
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv-{{ include "..fullname" . }}-backups
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc-{{ include "..fullname" . }}-backups
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-c2e6d82f

--- a/helm/youtrack-2/templates/volume-backups.yaml
+++ b/helm/youtrack-2/templates/volume-backups.yaml
@@ -49,10 +49,11 @@
 #   resources:
 #     requests:
 #       storage: 10Gi
+
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: "efs-sc-{{ include "..fullname" . }}-backups"
+  name: efs-sc-backups
   annotations:
     "helm.sh/hook": "pre-install"
 provisioner: efs.csi.aws.com
@@ -69,7 +70,7 @@ spec:
   # {{- end }}
   accessModes:
     - ReadWriteMany
-  storageClassName: "efs-sc-{{ include "..fullname" . }}-backups"
+  storageClassName: efs-sc-backups
   resources:
     requests:
       storage: 5Gi
@@ -87,7 +88,7 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: efs-sc-{{ include "..fullname" . }}-backups
+  storageClassName: efs-sc-backups
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: fs-c2e6d82f
+    volumeHandle: {{ .Values.efs_ids.backups }}

--- a/helm/youtrack-2/templates/volume-conf.yaml
+++ b/helm/youtrack-2/templates/volume-conf.yaml
@@ -49,13 +49,10 @@
 #   resources:
 #     requests:
 #       storage: 1Gi
-
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: "efs-sc-{{ include "..fullname" . }}-conf"
-  annotations:
-    "helm.sh/hook": "pre-install"
+  name: efs-sc-conf
 provisioner: efs.csi.aws.com
 ---
 apiVersion: v1
@@ -70,7 +67,7 @@ spec:
   # {{- end }}
   accessModes:
     - ReadWriteMany
-  storageClassName: "efs-sc-{{ include "..fullname" . }}-conf"
+  storageClassName: efs-sc-conf
   resources:
     requests:
       storage: 5Gi
@@ -88,7 +85,7 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: efs-sc-{{ include "..fullname" . }}-conf
+  storageClassName: efs-sc-conf
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: fs-c7e6d82a
+    volumeHandle: {{ .Values.efs_ids.conf }}

--- a/helm/youtrack-2/templates/volume-conf.yaml
+++ b/helm/youtrack-2/templates/volume-conf.yaml
@@ -1,0 +1,94 @@
+# {{- $useExisitingVolume := and .Values.existingVolumes.enabled (ne .Values.existingVolumes.conf "") }}
+# {{- if $useExisitingVolume -}}
+# kind: StorageClass
+# apiVersion: storage.k8s.io/v1
+# metadata:
+#   name: "sc-{{ include "..fullname" . }}-conf"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# provisioner: efs.csi.aws.com
+# parameters:
+#   type: gp2
+# reclaimPolicy: Retain
+# mountOptions:
+#   - debug
+# volumeBindingMode: Immediate
+# ---
+# apiVersion: v1
+# kind: PersistentVolume
+# metadata:
+#   name: "pv-{{ include "..fullname" . }}-conf"
+#   labels:
+#     type: amazonEBS
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   capacity:
+#     storage: 1Gi
+#   volumeMode: Filesystem
+#   accessModes:
+#     - ReadWriteOnce
+#   storageClassName: "sc-{{ include "..fullname" . }}-conf"
+#   csi:
+#     driver: efs.csi.aws.com
+#     volumeHandle: fs-8e4b7563
+# ---
+# {{- end -}}
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: "pvc-{{ include "..fullname" . }}-conf"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   {{- if $useExisitingVolume }}
+#   storageClassName: "sc-{{ include "..fullname" . }}-conf"
+#   {{- end }}
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 1Gi
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: "efs-sc-{{ include "..fullname" . }}-conf"
+  annotations:
+    "helm.sh/hook": "pre-install"
+provisioner: efs.csi.aws.com
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "efs-claim-{{ include "..fullname" . }}-conf"
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  # {{- if $useExisitingVolume }}
+  # storageClassName: "sc-{{ include "..fullname" . }}-conf"
+  # {{- end }}
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "efs-sc-{{ include "..fullname" . }}-conf"
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv-{{ include "..fullname" . }}-conf
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc-{{ include "..fullname" . }}-conf
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-c7e6d82a

--- a/helm/youtrack-2/templates/volume-data.yaml
+++ b/helm/youtrack-2/templates/volume-data.yaml
@@ -1,0 +1,94 @@
+# {{- $useExisitingVolume := and .Values.existingVolumes.enabled (ne .Values.existingVolumes.data "") }}
+# {{- if $useExisitingVolume -}}
+# kind: StorageClass
+# apiVersion: storage.k8s.io/v1
+# metadata:
+#   name: "sc-{{ include "..fullname" . }}-data"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# provisioner: efs.csi.aws.com
+# parameters:
+#   type: gp2
+# reclaimPolicy: Retain
+# mountOptions:
+#   - debug
+# volumeBindingMode: Immediate
+# ---
+# apiVersion: v1
+# kind: PersistentVolume
+# metadata:
+#   name: "pv-{{ include "..fullname" . }}-data"
+#   labels:
+#     type: amazonEBS
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   capacity:
+#     storage: 10Gi
+#   accessModes:
+#     - ReadWriteOnce
+#   volumeMode: Filesystem
+#   storageClassName: "sc-{{ include "..fullname" . }}-data"
+#   csi:  
+#     driver: efs.csi.aws.com
+#     volumeHandle: fs-8e4b7563
+# ---
+# {{- end -}}
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: "pvc-{{ include "..fullname" . }}-data"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   {{- if $useExisitingVolume }}
+#   storageClassName: "sc-{{ include "..fullname" . }}-data"
+#   {{- end }}
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 10Gi
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: "efs-sc-{{ include "..fullname" . }}-data"
+  annotations:
+    "helm.sh/hook": "pre-install"
+provisioner: efs.csi.aws.com
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "efs-claim-{{ include "..fullname" . }}-data"
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  # {{- if $useExisitingVolume }}
+  # storageClassName: "sc-{{ include "..fullname" . }}-data"
+  # {{- end }}
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "efs-sc-{{ include "..fullname" . }}-data"
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv-{{ include "..fullname" . }}-data
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc-{{ include "..fullname" . }}-data
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-0fedd3e2

--- a/helm/youtrack-2/templates/volume-data.yaml
+++ b/helm/youtrack-2/templates/volume-data.yaml
@@ -29,7 +29,7 @@
 #     - ReadWriteOnce
 #   volumeMode: Filesystem
 #   storageClassName: "sc-{{ include "..fullname" . }}-data"
-#   csi:  
+#   csi:
 #     driver: efs.csi.aws.com
 #     volumeHandle: fs-8e4b7563
 # ---
@@ -49,13 +49,10 @@
 #   resources:
 #     requests:
 #       storage: 10Gi
-
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: "efs-sc-{{ include "..fullname" . }}-data"
-  annotations:
-    "helm.sh/hook": "pre-install"
+  name: efs-sc-data
 provisioner: efs.csi.aws.com
 ---
 apiVersion: v1
@@ -70,7 +67,7 @@ spec:
   # {{- end }}
   accessModes:
     - ReadWriteMany
-  storageClassName: "efs-sc-{{ include "..fullname" . }}-data"
+  storageClassName: efs-sc-data
   resources:
     requests:
       storage: 5Gi
@@ -88,7 +85,7 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: efs-sc-{{ include "..fullname" . }}-data
+  storageClassName: efs-sc-data
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: fs-0fedd3e2
+    volumeHandle: {{ .Values.efs_ids.data }}

--- a/helm/youtrack-2/templates/volume-logs.yaml
+++ b/helm/youtrack-2/templates/volume-logs.yaml
@@ -1,0 +1,94 @@
+# {{- $useExisitingVolume := and .Values.existingVolumes.enabled (ne .Values.existingVolumes.logs "") }}
+# {{- if $useExisitingVolume -}}
+# kind: StorageClass
+# apiVersion: storage.k8s.io/v1
+# metadata:
+#   name: "sc-{{ include "..fullname" . }}-logs"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# provisioner: efs.csi.aws.com
+# parameters:
+#   type: gp2
+# reclaimPolicy: Retain
+# mountOptions:
+#   - debug
+# volumeBindingMode: Immediate
+# ---
+# apiVersion: v1
+# kind: PersistentVolume
+# metadata:
+#   name: "pv-{{ include "..fullname" . }}-logs"
+#   labels:
+#     type: amazonEBS
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   capacity:
+#     storage: 2Gi
+#   accessModes:
+#     - ReadWriteOnce
+#   volumeMode: Filesystem
+#   storageClassName: "sc-{{ include "..fullname" . }}-logs"
+#   csi:
+#     driver: efs.csi.aws.com
+#     volumeHandle: fs-8e4b7563
+# ---
+# {{- end -}}
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: "pvc-{{ include "..fullname" . }}-logs"
+#   annotations:
+#     "helm.sh/hook": "pre-install"
+# spec:
+#   {{- if $useExisitingVolume }}
+#   storageClassName: "sc-{{ include "..fullname" . }}-logs"
+#   {{- end }}
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 2Gi
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: "efs-sc-{{ include "..fullname" . }}-logs"
+  annotations:
+    "helm.sh/hook": "pre-install"
+provisioner: efs.csi.aws.com
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "efs-claim-{{ include "..fullname" . }}-logs"
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  # {{- if $useExisitingVolume }}
+  # storageClassName: "sc-{{ include "..fullname" . }}-logs"
+  # {{- end }}
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "efs-sc-{{ include "..fullname" . }}-logs"
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv-{{ include "..fullname" . }}-logs
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc-{{ include "..fullname" . }}-logs
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-d7e6d83a

--- a/helm/youtrack-2/templates/volume-logs.yaml
+++ b/helm/youtrack-2/templates/volume-logs.yaml
@@ -50,12 +50,11 @@
 #     requests:
 #       storage: 2Gi
 
+# INDIVIDUAL
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: "efs-sc-{{ include "..fullname" . }}-logs"
-  annotations:
-    "helm.sh/hook": "pre-install"
+  name: efs-sc-logs
 provisioner: efs.csi.aws.com
 ---
 apiVersion: v1
@@ -70,7 +69,7 @@ spec:
   # {{- end }}
   accessModes:
     - ReadWriteMany
-  storageClassName: "efs-sc-{{ include "..fullname" . }}-logs"
+  storageClassName: efs-sc-logs
   resources:
     requests:
       storage: 5Gi
@@ -88,7 +87,7 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: efs-sc-{{ include "..fullname" . }}-logs
+  storageClassName: efs-sc-logs
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: fs-d7e6d83a
+    volumeHandle: {{ .Values.efs_ids.logs }}

--- a/helm/youtrack-2/values.yaml
+++ b/helm/youtrack-2/values.yaml
@@ -1,0 +1,74 @@
+replicaCount: 1
+
+# https://hub.docker.com/r/jetbrains/youtrack/tags
+image:
+  repository: jetbrains/youtrack
+  tag: 2020.3.9516
+  pullPolicy: IfNotPresent
+
+nameOverride: youtrack-test
+fullnameOverride: youtrack-test
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:ca-central-1:491327797652:certificate/05414c50-3a2a-4c0e-aca3-b2fc717561ca"
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-1-2017-01
+    # see https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/tasks/ssl_redirect/
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    external-dns.alpha.kubernetes.io/hostname: "youtrack-test.buttoncloud.ca"
+
+  hosts:
+    - host: youtrack-test.buttoncloud.ca
+      paths: [""]
+
+  # tls:
+  #  - secretName: chart-example-tls
+  #    hosts: []
+
+# existingVolumes:
+#   enabled: true
+#   data: "vol-0f0eaf3f0da4efecc"
+#   logs: "vol-0693e17bd5c1d86a8"
+#   conf: "vol-06b35658f456c4a13"
+#   backups: "vol-0b201f8c49d7df4b9"
+
+existingVolumes:
+  enabled: false
+  data: "fsap-0e36124f77ed59011"
+  logs: "fsap-0e36124f77ed59011"
+  conf: "fsap-0e36124f77ed59011"
+  backups: "fsap-0e36124f77ed59011"
+
+securityContext:
+  runAsUser: 13001
+  runAsGroup: 13001
+  fsGroup: 13001
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  #
+  # see https://youtrack-support.jetbrains.com/hc/en-us/articles/206546119-What-hardware-requirements-does-YouTrack-have-
+  limits:
+    cpu: 1.5
+    memory: 3Gi
+  requests:
+    cpu: 1.5
+    memory: 3Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/youtrack-2/values.yaml
+++ b/helm/youtrack-2/values.yaml
@@ -72,3 +72,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+efs_ids:
+  data: fs-27261fca
+  conf: fs-26261fcb
+  logs: fs-24261fc9
+  backups: 	fs-21261fcc

--- a/main.tf
+++ b/main.tf
@@ -60,11 +60,25 @@ module "eks" {
 
   fargate_profiles = {
     argocd = {
-      namespace = "argocd"
-
       tags = {
         "managed-by" = "terraform"
-      }
+      },
+
+      selectors = [
+        {
+          namespace = "argocd"
+        }
+      ]
+    },
+    youtrack = {
+      tags = {
+        "managed-by" = "terraform"
+      },
+      selectors = [
+        {
+          namespace = "youtrack"
+        }
+      ]
     }
   }
 
@@ -108,4 +122,8 @@ module "acm" {
   source           = "button-inc/acm/aws"
   hosted_zone_name = "buttoncloud.ca."
   subdomain_names  = ["argocd", "youtrack"]
+}
+
+resource "aws_efs_file_system" "youtrack-efs" {
+  creation_token = "youtrack-efs"
 }

--- a/main.tf
+++ b/main.tf
@@ -121,9 +121,91 @@ module "eks_tools" {
 module "acm" {
   source           = "button-inc/acm/aws"
   hosted_zone_name = "buttoncloud.ca."
-  subdomain_names  = ["argocd", "youtrack"]
+  subdomain_names  = ["argocd", "youtrack"] # , "youtrack-test"]
 }
 
-resource "aws_efs_file_system" "youtrack-efs" {
-  creation_token = "youtrack-efs"
+#######################################################################
+
+locals {
+  file_systems = [
+    "youtrack_data",
+    "youtrack_conf",
+    "youtrack_logs",
+    "youtrack_backups",
+  ]
+}
+
+resource "aws_efs_file_system" "efs_youtrack" {
+  for_each       = toset(local.file_systems)
+  creation_token = each.key
+
+  # encrypted   = true
+  # kms_key_id  = ""
+
+  performance_mode = "generalPurpose" #maxIO
+  throughput_mode  = "bursting"
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+}
+
+data "aws_efs_file_system" "efs_youtrack_data" {
+  for_each       = aws_efs_file_system.efs_youtrack
+  file_system_id = each.value.id
+}
+
+resource "aws_efs_access_point" "efs_youtrack_data" {
+  for_each       = aws_efs_file_system.efs_youtrack
+  file_system_id = each.value.id
+}
+
+# Mount to the subnets that will be using this efs volume
+# Also attach sg's to restrict access to this volume
+resource "aws_efs_mount_target" "subnet_mount_1" {
+  for_each       = aws_efs_file_system.efs_youtrack
+  file_system_id = each.value.id
+  subnet_id      = module.vpc.private_subnets[0]
+
+  security_groups = [
+    aws_security_group.allow_eks_cluster.id
+  ]
+}
+
+resource "aws_efs_mount_target" "subnet_mount_2" {
+  for_each       = aws_efs_file_system.efs_youtrack
+  file_system_id = each.value.id
+  subnet_id      = module.vpc.private_subnets[1]
+
+  security_groups = [
+    aws_security_group.allow_eks_cluster.id
+  ]
+}
+
+# Security Groups for this volume
+resource "aws_security_group" "allow_eks_cluster" {
+  name        = "eks nfs group"
+  description = "This will allow the cluster to access this volume and use it."
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "NFS For EKS Cluster"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    security_groups = [
+      module.eks.cluster_primary_security_group_id
+    ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
 }


### PR DESCRIPTION
Draft for connecting youtrack to fargate with EFS volumes. Not currently working. Includes:

- Helm chart for the CSI driver
- Terraform updates to create EFS file systems, mounts, and security group
- youtrack-2 helm chart with changed pc, pvc and storage class definitions

To setup:
- apply the terraform changes, 
- install the CSI driver into the kube-system namespace with the helm chart
- Update youtrack values to include the new file system ids from terraform. Install youtrack-2 into the youtrack namespace with helm

The role the service account is using is created in AWS, if you describe the pvc's they give access denied errors. Stuck trying to figure it out, the CSI works with the examples given in its repo so I think the role policies should be set up correctly